### PR TITLE
Collision stamp

### DIFF
--- a/__tests__/privatize-plus-collision.js
+++ b/__tests__/privatize-plus-collision.js
@@ -1,0 +1,75 @@
+var compose = require('../packages/compose');
+var Collision = require('../packages/collision');
+var Privatize = require('../packages/privatize');
+
+describe('Collision + Privatize', function () {
+  it('work together', function () {
+    var Stamp = compose(
+      Collision,
+      Privatize,
+      {
+        methods: {
+          privateMethod: function () {}
+        }
+      }
+    )
+      .collisionsProtectAnyMethod()
+      .privatizeMethods('privateMethod');
+
+    var obj = Stamp();
+
+    expect(obj.privateMethod).toBeUndefined();
+  });
+
+  it('privatizes deferred methods', function () {
+    // General purpose behavior to defer "draw()" method collisions
+    var DeferDraw = Collision.collisionSetup({defer: ['draw']});
+
+    var Border = compose(DeferDraw, {
+      methods: {
+        draw: jest.fn() // Spy function
+      }
+    });
+    var Button = compose(DeferDraw, {
+      methods: {
+        draw: jest.fn() // Spy function
+      }
+    });
+
+    // General purpose behavior to privatize the "draw()" method
+    var PrivateDraw = Privatize.privatizeMethods('draw');
+
+    // General purpose behavior to forbid the "redraw()" method collision
+    var ForbidRedrawCollision = Collision.collisionSetup({forbid: ['redraw']});
+
+    // The aggregating component
+    var ModalDialog = compose(PrivateDraw) // privatize the "draw()" method
+      .compose(Border, Button) // modal will consist of Border and Button
+      .compose(ForbidRedrawCollision) // there can be only one "redraw()" method
+      .compose({
+        methods: {
+          // the public method which calls the deferred private methods
+          redraw: function (int) {
+            this.draw(int);
+          }
+        }
+      });
+
+    // Creating an instance of the stamp
+    var dialog = ModalDialog();
+
+    // Check if the "draw()" method is actually privatized
+    expect(dialog.draw).toBeUndefined();
+
+    // Calling the public method, which calls the deferred private methods
+    dialog.redraw(42);
+
+    // Check if the spy "draw()" deferred functions were actually invoked
+    expect(Border.compose.methods.draw).toBeCalledWith(42);
+    expect(Button.compose.methods.draw).toBeCalledWith(42);
+
+    // Make sure the ModalDialog throws every time on the "redraw()" collisions
+    const HaveRedraw = compose({methods: {redraw: jest.fn()}});
+    expect(function () {compose(ModalDialog, HaveRedraw)}).toThrow();
+  });
+});

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.34",
+  "lerna": "2.0.0-beta.36",
   "version": "independent",
   "publishConfig": {
     "ignore": [

--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,12 @@
 {
   "lerna": "2.0.0-beta.36",
   "version": "independent",
-  "publishConfig": {
-    "ignore": [
-      "ignored-file",
-      "*.md"
-    ]
+  "commands": {
+    "publish": {
+      "ignore": [
+        "ignored-file",
+        "*.md"
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "jest": "^18.0.0",
     "jshint": "^2.9.4",
-    "lerna": "^2.0.0-beta.34"
+    "lerna": "^2.0.0-beta.36"
   },
   "jshintConfig": {
     "node": true,
@@ -53,7 +53,8 @@
   },
   "jest": {
     "coverageReporters": [
-      "html", "text"
+      "html",
+      "text"
     ]
   }
 }

--- a/packages/collision/README.md
+++ b/packages/collision/README.md
@@ -19,6 +19,22 @@ const component = UiComponent();
 component.draw(); // will draw() all three primitives
 ```
 
+## API
+
+### Static methods
+
+#### collisionSetup
+Forbid or Defer an exclusive method
+`stamp.collisionSetup({forbid: ['methodName1'], defer: ['methodName2']}) -> Stamp`
+
+#### collisionsProtectAnyMethod
+Forbid any collisions
+`stamp.collisionsProtectAnyMethod() -> Stamp`
+
+#### collisionSettingsReset
+Remove any Collision settings from the stamp
+`stamp.collisionSettingsReset() -> Stamp`
+
 ## Example
 
 See the comments in the code:

--- a/packages/collision/README.md
+++ b/packages/collision/README.md
@@ -1,0 +1,11 @@
+# @stamp/collision
+
+_..._
+
+## Usage
+```js
+```
+
+## Example
+```js
+```

--- a/packages/collision/README.md
+++ b/packages/collision/README.md
@@ -1,11 +1,79 @@
 # @stamp/collision
 
-_..._
+_Controls collision behavior: forbid or defer_
+
+The `defer` collects same named methods and wraps them into a single method.
+
+This stamp (aka behavior) will check on every `compose` call if there are any conflicts. Throws an `Error` in case of a forbidden collision or ambiguous setup.
 
 ## Usage
 ```js
+import Collision from '@stamp/collision';
+
+import {Border, Button, Graph} from './drawable/primitives';
+
+const UiComponent = Collision.collisionSetup({defer: ['draw']})
+.compose(Border, Button, Graph);
+
+const component = UiComponent();
+component.draw(); // will draw() all three primitives
 ```
 
 ## Example
+
+See the comments in the code:
 ```js
+import compose from '@stamp/compose';
+import Collision from '@stamp/collision';
+import Privatize from '@stamp/privatize';
+
+// General purpose behavior to defer "draw()" method collisions
+const DeferDraw = Collision.collisionSetup({defer: ['draw']});
+
+const Border = compose(DeferDraw, {
+  methods: {
+    draw: jest.fn() // Spy function
+  }
+});
+const Button = compose(DeferDraw, {
+  methods: {
+    draw: jest.fn() // Spy function
+  }
+});
+
+// General purpose behavior to privatize the "draw()" method
+const PrivateDraw = Privatize.privatizeMethods('draw');
+
+// General purpose behavior to forbid the "redraw()" method collision
+const ForbidRedrawCollision = Collision.collisionSetup({forbid: ['redraw']});
+
+// The aggregating component
+const ModalDialog = compose(PrivateDraw) // privatize the "draw()" method
+  .compose(Border, Button) // modal will consist of Border and Button
+  .compose(ForbidRedrawCollision) // there can be only one "redraw()" method
+  .compose({
+    methods: {
+      // the public method which calls the deferred private methods
+      redraw(int) {
+        this.draw(int);
+      }
+    }
+  });
+
+// Creating an instance of the stamp
+const dialog = ModalDialog();
+
+// Check if the "draw()" method is actually privatized
+expect(dialog.draw).toBeUndefined();
+
+// Calling the public method, which calls the deferred private methods
+dialog.redraw(42);
+
+// Check if the spy "draw()" deferred functions were actually invoked
+expect(Border.compose.methods.draw).toBeCalledWith(42);
+expect(Button.compose.methods.draw).toBeCalledWith(42);
+
+// Make sure the ModalDialog throws every time on the "redraw()" collisions
+const HaveRedraw = compose({methods: {redraw() {}}})
+expect(() => compose(ModalDialog, HaveRedraw)).toThrow();
 ```

--- a/packages/collision/__tests__/index.js
+++ b/packages/collision/__tests__/index.js
@@ -2,7 +2,55 @@ var compose = require('@stamp/compose');
 var Collision = require('..');
 
 describe('@stamp/collision', function () {
-  it('???', function () {
-    Collision.compose();
+  it('defer', function () {
+    var draw1 = jest.fn();
+    var Defer1 = compose({
+        methods: {
+          draw: draw1
+        }
+      },
+      Collision.setupCollision({defer: ['draw']})
+    );
+    var draw2 = jest.fn();
+    var Defer2 = Collision.setupCollision({defer: ['draw']}).compose({
+      methods: {
+        draw: draw2
+      }
+    });
+
+    var StampCombined = compose(Defer1, Defer2);
+    var obj = StampCombined();
+
+    obj.draw();
+
+    expect(draw1).toBeCalled();
+    expect(draw2).toBeCalled();
   });
+
+  it('forbid', function () {
+    var Forbid = compose({
+        methods: {
+          draw: function () {}
+        }
+      },
+      Collision.setupCollision({forbid: ['draw']})
+    );
+    var Defer = compose({
+        methods: {
+          draw: function () {}
+        }
+      },
+      Collision.setupCollision({defer: ['draw']})
+    );
+    var Allow = compose({
+        methods: {
+          draw: function () {}
+        }
+      },
+      Collision.setupCollision({allow: ['draw']})
+    );
+
+    expect(function () {compose(Forbid, Defer)}).toThrow();
+    expect(function () {compose(Forbid, Allow)}).toThrow();
+  })
 });

--- a/packages/collision/__tests__/index.js
+++ b/packages/collision/__tests__/index.js
@@ -9,10 +9,10 @@ describe('@stamp/collision', function () {
           draw: draw1
         }
       },
-      Collision.setupCollision({defer: ['draw']})
+      Collision.collisionSetup({defer: ['draw']})
     );
     var draw2 = jest.fn();
-    var Defer2 = Collision.setupCollision({defer: ['draw']}).compose({
+    var Defer2 = Collision.collisionSetup({defer: ['draw']}).compose({
       methods: {
         draw: draw2
       }
@@ -27,30 +27,175 @@ describe('@stamp/collision', function () {
     expect(draw2).toBeCalled();
   });
 
+  it('defer + regular', function () {
+    var Defer = compose({
+        methods: {
+          draw: function () {}
+        }
+      },
+      Collision.collisionSetup({defer: ['draw']})
+    );
+    var Regular = compose({methods: {draw: function () {}}});
+
+    expect(function () {compose(Defer, Regular)}).toThrow();
+    expect(function () {compose(Regular, Defer)}).toThrow();
+  });
+
+
+  it('defer without conflicts', function () {
+    var Defer = compose({
+        methods: {
+          draw: function () {}
+        }
+      },
+      Collision.collisionSetup({defer: ['draw']})
+    );
+    var Regular = compose({
+      methods: {
+        whatever: function () {}
+      }
+    });
+
+    expect(function () {compose(Defer, Regular)}).not.toThrow();
+    expect(function () {compose(Regular, Defer)}).not.toThrow();
+  });
+
   it('forbid', function () {
     var Forbid = compose({
         methods: {
           draw: function () {}
         }
       },
-      Collision.setupCollision({forbid: ['draw']})
+      Collision.collisionSetup({forbid: ['draw']})
     );
     var Defer = compose({
         methods: {
           draw: function () {}
         }
       },
-      Collision.setupCollision({defer: ['draw']})
+      Collision.collisionSetup({defer: ['draw']})
     );
-    var Allow = compose({
+    var Regular = compose({
+        methods: {
+          draw: function () {}
+        }
+      }
+    );
+
+    expect(function () {compose(Forbid, Defer)}).toThrow();
+    expect(function () {compose(Forbid, Regular)}).toThrow();
+    expect(function () {compose(Defer, Forbid)}).toThrow();
+    expect(function () {compose(Regular, Forbid)}).toThrow();
+  });
+
+  it('collisionsProtectAnyMethod', function () {
+    var FooBar = compose({
+        methods: {
+          foo: function () {},
+          bar: function () {}
+        }
+      },
+      Collision.collisionsProtectAnyMethod()
+    );
+    var Foo = compose({
+        methods: {
+          foo: function () {}
+        }
+      },
+      Collision.collisionsProtectAnyMethod()
+    );
+    var Bar = compose({
+        methods: {
+          bar: function () {}
+        }
+      },
+      Collision.collisionsProtectAnyMethod()
+    );
+
+    expect(function () {compose(FooBar, Foo)}).toThrow();
+    expect(function () {compose(Foo, FooBar)}).toThrow();
+    expect(function () {compose(FooBar, Bar)}).toThrow();
+    expect(function () {compose(Bar, FooBar)}).toThrow();
+    expect(function () {compose(Foo, Bar)}).not.toThrow();
+    expect(function () {compose(Bar, Foo)}).not.toThrow();
+  });
+
+  it('forbid without conflicts', function () {
+    var Forbid = compose({
         methods: {
           draw: function () {}
         }
       },
-      Collision.setupCollision({allow: ['draw']})
+      Collision.collisionSetup({forbid: ['draw']})
+    );
+    var Regular = compose({
+        methods: {
+          whatever: function () {}
+        }
+      }
     );
 
-    expect(function () {compose(Forbid, Defer)}).toThrow();
-    expect(function () {compose(Forbid, Allow)}).toThrow();
-  })
+    expect(function () {compose(Forbid, Regular)}).not.toThrow();
+    expect(function () {compose(Regular, Forbid)}).not.toThrow();
+  });
+
+  it('collisionSettingsReset', function () {
+    var Forbid = compose({
+        methods: {
+          draw: function () {}
+        }
+      },
+      Collision.collisionSetup({forbid: ['draw']})
+    );
+    var Resetted1 = Forbid.collisionSettingsReset();
+    var Defer = compose({
+        methods: {
+          draw: function () {}
+        }
+      },
+      Collision.collisionSetup({defer: ['draw']})
+    );
+    var Resetted2 = Defer.collisionSettingsReset();
+    var Regular = compose({
+        methods: {
+          draw: function () {}
+        }
+      }
+    );
+
+    expect(function () {compose(Resetted1, Resetted2)}).not.toThrow();
+    expect(function () {compose(Resetted1, Regular)}).not.toThrow();
+    expect(function () {compose(Resetted2, Resetted1)}).not.toThrow();
+    expect(function () {compose(Regular, Resetted1)}).not.toThrow();
+  });
+
+  it('broken metadata', function () {
+    var UndefinedMethod = Collision
+      .collisionSetup({forbid: ['foo']})
+      .compose({
+        methods: {
+          draw: null
+        }
+      });
+
+    var NoDefer = compose(Collision, {
+        methods: {
+          draw: function () {}
+        }
+      }
+    );
+    NoDefer.compose.deepConfiguration.Collision.defer = null;
+
+    var NoForbid = compose(Collision, {
+        methods: {
+          draw: function () {}
+        }
+      }
+    );
+    NoForbid.compose.deepConfiguration.Collision.forbid = null;
+
+
+    expect(function () {compose(UndefinedMethod, NoForbid)}).not.toThrow();
+    expect(function () {compose(UndefinedMethod, NoDefer)}).not.toThrow();
+  });
 });

--- a/packages/collision/__tests__/index.js
+++ b/packages/collision/__tests__/index.js
@@ -1,0 +1,8 @@
+var compose = require('@stamp/compose');
+var Collision = require('..');
+
+describe('@stamp/collision', function () {
+  it('???', function () {
+    Collision.compose();
+  });
+});

--- a/packages/collision/index.js
+++ b/packages/collision/index.js
@@ -16,7 +16,7 @@ function makeProxyFunction(functions, name) {
   function deferredFn() {
     'use strict';
     for (var i = 0; i < functions.length; i++) {
-      functions[i].apply(this, arguments);
+      functions[i].apply(this, arguments); // jshint ignore:line
     }
   }
 

--- a/packages/collision/index.js
+++ b/packages/collision/index.js
@@ -1,34 +1,148 @@
 var compose = require('@stamp/compose');
 var isStamp = require('@stamp/is/stamp');
 var isObject = require('@stamp/is/object');
+var isArray = require('@stamp/is/array');
+
+function dedupe(array) {
+  var result = [];
+  for (var i = 0; i < array.length; i++) {
+    var item = array[i];
+    if (result.indexOf(item) < 0) result.push(item);
+  }
+  return result;
+}
+
+function makeProxyFunction(functions, name) {
+  function deferredFn() {
+    'use strict';
+    for (var i = 0; i < functions.length; i++) {
+      functions[i].apply(this, arguments);
+    }
+  }
+
+  Object.defineProperty(deferredFn, 'name', {
+    value: name,
+    configurable: true
+  });
+
+  return deferredFn;
+}
+
+function getCollisionSettings(descriptor) {
+  return descriptor &&
+    descriptor.deepConfiguration &&
+    descriptor.deepConfiguration.Collision;
+}
+
+function descriptorHasSetting(descriptor, setting, methodName) {
+  var settings = getCollisionSettings(descriptor);
+  var settingsFor = settings && settings[setting];
+  return isArray(settingsFor) && settingsFor.indexOf(methodName) >= 0;
+}
+
+function forbidsCollision(descriptor, methodName) {
+  var settings = getCollisionSettings(descriptor);
+  if (settings && settings.forbidAll) return true;
+  return descriptorHasSetting(descriptor, 'forbid', methodName);
+}
+
+function defersCollision(descriptor, methodName) {
+  return descriptorHasSetting(descriptor, 'defer', methodName);
+}
 
 module.exports = compose({
-  deepConfiguration: {Privatize: {methods: []}},
+  deepConfiguration: {Collision: {defer: [], forbid: []}},
   staticProperties: {
-    methodCollisions: function () {
-      return this.compose({
-        deepConfiguration: {
-          Collision: {}
-        }
-      });
+    setupCollision: function (opts) {
+      return this.compose({deepConfiguration: {Collision: opts}});
+    },
+    resetCollisionSettings: function () {
+      return this.setupCollision(null);
+    },
+    protectFromAnyCollisions: function () {
+      return this.setupCollision({forbidAll: true});
     }
   },
   composers: [function (opts) {
-    var methods = opts.stamp.compose.methods;
-    var composables = opts.composables;
-    var methodsMetadata = {};
-    for (var i = 0; i < composables.length; i++) {
-      var c = composables;
-      c = isStamp(c) ? c.compose : c;
-      if (isObject(c.methods)) {
-        var methodNames = Object.keys(c.methods);
-        for (var j = 0; j < methodNames.length; j++) {
-          var name = methodNames[j];
+    var descriptor = opts.stamp.compose;
+    var settings = getCollisionSettings(descriptor);
 
+    var i, methodName;
+    if (settings) {
+      // Deduping is an important part of the logic
+      if (isArray(settings.defer)) {
+        settings.defer = dedupe(settings.defer);
+      }
+      if (isArray(settings.forbid)) {
+        settings.forbid = dedupe(settings.forbid);
+      }
 
+      // Make sure settings are not ambiguous
+      if (isArray(settings.defer) && isArray(settings.forbid)) {
+        for (i = 0; i < settings.forbid.length; i++) {
+          methodName = settings.forbid[i];
+          if (settings.defer.indexOf(methodName) >= 0) {
+            throw new Error('Ambiguous Collision settings. The `' + methodName +
+              '` is both deferred and forbidden');
+          }
         }
       }
     }
 
+    if (settings && (
+        isArray(settings.defer) && settings.defer.length > 0 ||
+        isArray(settings.forbid) && settings.forbid.length > 0
+      )) {
+      var d, j, oneMetadata;
+
+      var methodsMetadata = {}; // methods aggregation
+      var composables = opts.composables;
+      for (i = 0; i < composables.length; i++) {
+        d = composables[i];
+        d = isStamp(d) ? d.compose : d;
+        if (!isObject(d.methods)) continue;
+
+        var methodNames = Object.keys(d.methods);
+        for (j = 0; j < methodNames.length; j++) {
+          methodName = methodNames[j];
+          var method = d.methods[methodName];
+          if (!method) continue;
+
+          oneMetadata = methodsMetadata[methodName];
+          if (!oneMetadata) {
+            methodsMetadata[methodName] = method;
+            continue;
+          }
+
+          if (forbidsCollision(descriptor, methodName)) {
+            throw new Error('Collision of method `' + methodName +
+              '` is forbidden');
+          }
+
+          if (defersCollision(d, methodName)) {
+            var arr = isArray(oneMetadata) ? oneMetadata : [oneMetadata];
+            arr.push(method);
+            methodsMetadata[methodName] = arr;
+            continue;
+          }
+
+          methodsMetadata[methodName] = method;
+        }
+      }
+
+      var methods = opts.stamp.compose.methods;
+      var allMetadataMethods = Object.keys(methodsMetadata);
+      for (i = 0; i < allMetadataMethods.length; i++) {
+        methodName = allMetadataMethods[i];
+        oneMetadata = methodsMetadata[methodName];
+        if (isArray(oneMetadata) && oneMetadata.length > 1) {
+          // Some collisions aggregated to a single method
+          // Mutating the resulting stamp
+          methods[methodName] = makeProxyFunction(oneMetadata, methodName);
+        } else {
+          methods[methodName] = oneMetadata;
+        }
+      }
+    }
   }]
 });

--- a/packages/collision/index.js
+++ b/packages/collision/index.js
@@ -1,0 +1,34 @@
+var compose = require('@stamp/compose');
+var isStamp = require('@stamp/is/stamp');
+var isObject = require('@stamp/is/object');
+
+module.exports = compose({
+  deepConfiguration: {Privatize: {methods: []}},
+  staticProperties: {
+    methodCollisions: function () {
+      return this.compose({
+        deepConfiguration: {
+          Collision: {}
+        }
+      });
+    }
+  },
+  composers: [function (opts) {
+    var methods = opts.stamp.compose.methods;
+    var composables = opts.composables;
+    var methodsMetadata = {};
+    for (var i = 0; i < composables.length; i++) {
+      var c = composables;
+      c = isStamp(c) ? c.compose : c;
+      if (isObject(c.methods)) {
+        var methodNames = Object.keys(c.methods);
+        for (var j = 0; j < methodNames.length; j++) {
+          var name = methodNames[j];
+
+
+        }
+      }
+    }
+
+  }]
+});

--- a/packages/collision/package.json
+++ b/packages/collision/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/collision",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Detect and manipulate method collisions",
   "main": "index.js",
   "repository": {

--- a/packages/collision/package.json
+++ b/packages/collision/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@stamp/collision",
+  "version": "0.0.1",
+  "description": "Detect and manipulate method collisions",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stampit-org/stamp/tree/master/packages/collision"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@stamp/compose": "^0.1.1",
+    "@stamp/is": "^0.1.1"
+  }
+}


### PR DESCRIPTION
Allows to:
* Forbid any method collisions
* Forbid individual method collisions
* Defer method collisions and wrap them into a single aggregation method