### PR TITLE
Add configure stamp

### DIFF
--- a/packages/privatize/configure.js
+++ b/packages/privatize/configure.js
@@ -1,0 +1,10 @@
+var compose = require('@stamp/compose');
+
+function initializer(_, opts) {
+    this.stampConfiguration = opts.stamp.compose.configuration;
+    this.stampDeepConfiguration = opts.stamp.compose.deepConfiguration;
+}
+
+module.exports = compose({
+  initializers: [initializer]
+});


### PR DESCRIPTION
It's very trivial and doesn't make much sense for regular stamps. However, with Privatize it's perfectly sane to do this since it will disappear from replaced instanced.

```js
import Configure from '@stamp/privatize/configure';
import Privatize from '@stamp/privatize';

compose(Configure, Privatize, {
    configuration: {
        secret: 'mykey'
    },
    methods: {
        encrypt(value) {
          const { secret } = this.stampConfiguration;
          // run encryption with secret while it's still hidden from outside
        }
    }
})
```

Thinking if it would actually good idea to incorporate it as *optional* part of Privatize stamp to avoid double import. Something like `compose(Privatize.withConfigure())`. Or simple static property to allow `import Privatize, { Configure } from '@stamp/privatize'`. What do you think @koresar ?