### PR TITLE
Import static helper methods

### DIFF
--- a/__tests__/privatize-plus-collision.js
+++ b/__tests__/privatize-plus-collision.js
@@ -69,7 +69,7 @@ describe('Collision + Privatize', function () {
     expect(Button.compose.methods.draw).toBeCalledWith(42);
 
     // Make sure the ModalDialog throws every time on the "redraw()" collisions
-    const HaveRedraw = compose({methods: {redraw: jest.fn()}});
+    var HaveRedraw = compose({methods: {redraw: jest.fn()}});
     expect(function () {compose(ModalDialog, HaveRedraw)}).toThrow();
   });
 });

--- a/lerna.json
+++ b/lerna.json
@@ -5,9 +5,9 @@
     "publish": {
       "access": "public",
       "ignore": [
-        "ignored-file",
-        "*.md"
-      ]
+        "__tests__/"
+      ],
+      "npmClientArgs": ["--access public"]
     }
   },
   "npmClientArgs": ["--access public"]

--- a/packages/arg-over-prop/README.md
+++ b/packages/arg-over-prop/README.md
@@ -23,6 +23,13 @@ A shorter but identical version of the same `StampA`:
 const StampA = ArgOverProp.argOverProp({foo: 1});
 ```
 
+Or if you don't want to import the stamp you can import only the method:
+```js
+import {argOverProp} from '@stamp/arg-over-prop';
+const StampA = argOverProp({foo: 1});
+```
+
+
 Basically, the `arg-over-prop` stamp sets properties in an initializer.
 The code below is what the `StampA` becomes.
 ```js

--- a/packages/arg-over-prop/__tests__/index.js
+++ b/packages/arg-over-prop/__tests__/index.js
@@ -1,6 +1,15 @@
 var ArgOverProp = require('..');
 
 describe('@stamp/arg-over-prop', function () {
+  it('can be used as a standalone function', function () {
+    var argOverProp = ArgOverProp.argOverProp;
+    var Stamp = argOverProp('override');
+    var instance = Stamp({override: 1, dontTouch: 2});
+
+    expect(instance.override).toBe(1);
+    expect(instance).not.toHaveProperty('dontTouch');
+  });
+
   it('assigns only the requested properties', function () {
     var Stamp = ArgOverProp.argOverProp('override');
     var instance = Stamp({override: 1, dontTouch: 2});

--- a/packages/arg-over-prop/index.js
+++ b/packages/arg-over-prop/index.js
@@ -25,10 +25,11 @@ function dedupe(array) {
   return result;
 }
 
-module.exports = compose({
+var ArgOverProp = compose({
   staticProperties: {
     argOverProp: function () {
-      var propNames = [], defaultProps = {};
+      'use strict';
+      var propNames = [], defaultProps;
       for (var i = 0; i < arguments.length; i++) {
         var arg = arguments[i];
         if (isString(arg)) {
@@ -37,12 +38,13 @@ module.exports = compose({
         else if (isArray(arg)) {
           propNames = propNames.concat(arg.filter(isString));
         } else if (isObject(arg)) {
-          assign(defaultProps, arg);
+          defaultProps = assign(defaultProps || {}, arg);
           propNames = propNames.concat(Object.keys(arg));
         }
       }
 
-      return this.compose({
+      var Stamp = this && this.compose ? this : ArgOverProp;
+      return Stamp.compose({
         deepConfiguration: {ArgOverProp: propNames},
         properties: defaultProps // default property values
       });
@@ -62,3 +64,5 @@ module.exports = compose({
     conf.ArgOverProp = dedupe(propNames);
   }]
 });
+
+module.exports = ArgOverProp;

--- a/packages/arg-over-prop/package.json
+++ b/packages/arg-over-prop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/arg-over-prop",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Assign properties passed to the stamp factory",
   "main": "index.js",
   "repository": {
@@ -10,8 +10,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@stamp/compose": "^0.1.6",
-    "@stamp/core": "^0.1.2",
-    "@stamp/is": "^0.2.0"
+    "@stamp/compose": "^1.0.0",
+    "@stamp/core": "^1.0.0",
+    "@stamp/is": "^1.0.0"
   }
 }

--- a/packages/check-compose/package.json
+++ b/packages/check-compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/check-compose",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "description": "Command line tool to test your 'compose' function implementation",
   "repository": "https://github.com/stampit-org/stamp/tree/master/packages/check-compose",

--- a/packages/collision/README.md
+++ b/packages/collision/README.md
@@ -2,11 +2,25 @@
 
 _Controls collision behavior: forbid or defer_
 
-The `defer` collects same named methods and wraps them into a single method.
-
-This stamp (aka behavior) will check on every `compose` call if there are any conflicts. Throws an `Error` in case of a forbidden collision or ambiguous setup.
+This stamp (aka behavior) will check if there are any conflicts on every `compose` call. 
+Throws an `Error` in case of a forbidden collision or ambiguous setup.
 
 ## Usage
+
+```js
+import Collision from '@stamp/collision';
+
+const ForbidRedrawCollision = Collision.collisionSetup({forbid: ['redraw']});
+```
+
+Or if you don't want to import the stamp you can import only the method:
+```js
+import {collisionSetup} from '@stamp/collision';
+const ForbidRedrawCollision = collisionSetup({forbid: ['redraw']});
+```
+
+
+The `defer` collects same named methods and wraps them into a single method.
 ```js
 import Collision from '@stamp/collision';
 

--- a/packages/collision/__tests__/index.js
+++ b/packages/collision/__tests__/index.js
@@ -173,7 +173,12 @@ describe('@stamp/collision', function () {
   });
 
   it('forbid + allow', function () {
-    expect(function () {Collision.collisionSetup({allow: ['foo'], forbid: ['foo']})}).toThrow();
+    expect(function () {Collision.collisionSetup({allow: ['foo'], forbid: ['foo']})}).toThrow(/Collision/);
+  });
+
+  it('can be used as a standalone function', function () {
+    var collisionSetup = Collision.collisionSetup;
+    expect(function () {collisionSetup({allow: ['foo'], forbid: ['foo']})}).toThrow(/Collision/);
   });
 
   it('forbid without conflicts', function () {

--- a/packages/collision/index.js
+++ b/packages/collision/index.js
@@ -53,11 +53,14 @@ function defersCollision(descriptor, methodName) {
   return descriptorHasSetting(descriptor, 'defer', methodName);
 }
 
-module.exports = compose({
+var Collision = compose({
   deepConfiguration: {Collision: {defer: [], forbid: []}},
   staticProperties: {
     collisionSetup: function (opts) {
-      return this.compose({deepConfiguration: {Collision: opts}});
+      'use strict';
+      var Stamp = this && this.compose ? this : Collision;
+      return Stamp.compose({deepConfiguration: {Collision: opts}});
+
     },
     collisionSettingsReset: function () {
       return this.collisionSetup(null);
@@ -178,3 +181,5 @@ module.exports = compose({
     }
   }]
 });
+
+module.exports = Collision;

--- a/packages/collision/package.json
+++ b/packages/collision/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/collision",
-  "version": "0.2.5",
+  "version": "1.0.0",
   "description": "Detect and manipulate method collisions",
   "main": "index.js",
   "repository": {
@@ -10,8 +10,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@stamp/compose": "^0.1.6",
-    "@stamp/core": "^0.1.2",
+    "@stamp/compose": "^1.0.0",
+    "@stamp/core": "^1.0.0",
     "@stamp/is": "^0.1.1"
   }
 }

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/compose",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "Compose function implementation to create stamps",
   "repository": "https://github.com/stampit-org/stamp/tree/master/packages/compose",
@@ -18,10 +18,10 @@
     "stamp"
   ],
   "dependencies": {
-    "@stamp/core": "^0.1.2",
+    "@stamp/core": "^1.0.0",
     "@stamp/is": "^0.1.2"
   },
   "devDependencies": {
-    "@stamp/check-compose": "^1.0.2"
+    "@stamp/check-compose": "^1.0.3"
   }
 }

--- a/packages/configure/package.json
+++ b/packages/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/configure",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "Access configuration of your stamps anywhere",
   "repository": "https://github.com/stampit-org/stamp/tree/master/packages/configure",
@@ -9,7 +9,7 @@
     "configure"
   ],
   "dependencies": {
-    "@stamp/compose": "^0.1.6",
-    "@stamp/privatize": "^0.1.7"
+    "@stamp/compose": "^1.0.0",
+    "@stamp/privatize": "^1.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/core",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "Core functions for creating stamps",
   "repository": "https://github.com/stampit-org/stamp/tree/master/packages/core",

--- a/packages/eventemittable/__tests__/eventemittable.js
+++ b/packages/eventemittable/__tests__/eventemittable.js
@@ -21,8 +21,8 @@ describe('EventEmittable', function () {
     });
 
     it('should not overwrite collided methods', function () {
-      const on = jest.fn();
-      const off = jest.fn();
+      var on = jest.fn();
+      var off = jest.fn();
       var MyStamp = compose(EventEmittable, {
         methods: {on: on, off: off}
       });

--- a/packages/eventemittable/package.json
+++ b/packages/eventemittable/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@stamp/eventemittable",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "Node.js' EventEmitter as a stamp",
   "repository": "https://github.com/stampit-org/stamp/tree/master/packages/eventemittable",
   "dependencies": {
-    "@stamp/compose": "^0.1.6",
+    "@stamp/compose": "^1.0.0",
     "events": "^1.1.1"
   }
 }

--- a/packages/fp-constructor/package.json
+++ b/packages/fp-constructor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/fp-constructor",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Adds the Functional Programming capabilities to your stamps",
   "main": "index.js",
   "repository": {
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@stamp/compose": "^0.1.6"
+    "@stamp/compose": "^1.0.0"
   }
 }

--- a/packages/init-property/package.json
+++ b/packages/init-property/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/init-property",
-  "version": "0.1.7",
+  "version": "1.0.0",
   "description": "Replaces properties which reference stamps with objects created from the stamps",
   "main": "index.js",
   "repository": {
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@stamp/compose": "^0.1.6",
+    "@stamp/compose": "^1.0.0",
     "@stamp/is": "^0.1.2"
   }
 }

--- a/packages/is/package.json
+++ b/packages/is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/is",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "Various checking functions used with stamps",
   "repository": "https://github.com/stampit-org/stamp/tree/master/packages/is"

--- a/packages/it/package.json
+++ b/packages/it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/it",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "A nice, handy API implementation of the compose standard",
   "main": "index.js",
   "repository": {
@@ -10,13 +10,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@stamp/compose": "^0.1.6",
-    "@stamp/core": "^0.1.2",
+    "@stamp/compose": "^1.0.0",
+    "@stamp/core": "^1.0.0",
     "@stamp/is": "^0.1.2",
-    "@stamp/shortcut": "^0.4.1"
+    "@stamp/shortcut": "^1.0.0"
   },
   "devDependencies": {
-    "@stamp/check-compose": "^1.0.2",
+    "@stamp/check-compose": "^1.0.3",
     "lodash": "^4.17.4"
   }
 }

--- a/packages/named/README.md
+++ b/packages/named/README.md
@@ -19,6 +19,16 @@ New behaviour:
 import Named from '@stamp/named';
 
 const MyNamedStamp = MyRegularStamp.compose(Named).setName('MyNamedStamp');
+```
+
+Or if you don't want to import the stamp you can import only the method:
+```js
+import {setName} from '@stamp/named';
+const MyNamedStamp = MyRegularStamp.compose(setName('MyNamedStamp'));
+```
+
+Then stamp receives a different name instead of the default "Stamp":
+```js
 console.log(MyNamedStamp.name); // 'MyNamedStamp'
 ```
 

--- a/packages/named/__tests__/index.js
+++ b/packages/named/__tests__/index.js
@@ -6,17 +6,23 @@ var Named = require('..');
 // Thus, there is no risk running these test in a non-supported platform.
 describe('@stamp/named', function () {
   it('default name is "Stamp"', function () {
-    const S = compose();
+    var S = compose();
     expect(S.name).toBe('Stamp');
   });
 
   it('setName sets the name', function () {
-    const S = compose(Named).setName('foo');
+    var S = compose(Named).setName('foo');
     expect(S.name).toBe('foo');
   });
 
   it('setName overwrites existing name', function () {
-    const S = compose(Named).setName('foo');
+    var S = compose(Named).setName('foo');
     expect(S.setName('bar').name).toBe('bar');
+  });
+
+  it('can be used as a standalone function', function () {
+    var setName = Named.setName;
+    var S = setName('foo');
+    expect(S.name).toBe('foo');
   });
 });

--- a/packages/named/index.js
+++ b/packages/named/index.js
@@ -1,9 +1,11 @@
 var compose = require('@stamp/compose');
 
-module.exports = compose({
+var Named = compose({
   staticProperties: {
     setName: function (name) {
-      return this.compose({
+      'use strict';
+      var Stamp = this && this.compose ? this : Named;
+      return Stamp.compose({
         staticPropertyDescriptors: {
           name: {
             value: name
@@ -13,3 +15,5 @@ module.exports = compose({
     }
   }
 });
+
+module.exports = Named;

--- a/packages/named/package.json
+++ b/packages/named/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/named",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "(Re)Name a stamp factory function",
   "main": "index.js",
   "repository": {
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@stamp/compose": "^0.1.5"
+    "@stamp/compose": "^1.0.0"
   }
 }

--- a/packages/privatize/README.md
+++ b/packages/privatize/README.md
@@ -19,6 +19,12 @@ const AuthWithPrivateProperties = Auth.compose(Privatize);
 const AuthWithPrivatePropertiesAndMethod = Auth.compose(Privatize).privatizeMethods('setPassword');
 ```
 
+Or if you don't want to import the stamp you can import only the method:
+```js
+import {privatizeMethods} from '@stamp/privatize';
+const AuthWithPrivatePropertiesAndMethod = Auth.compose(privatizeMethods('setPassword'));
+```
+
 ## Warning!
 Every property you assign in the initializers will be private.
 ```js

--- a/packages/privatize/__tests__/index.js
+++ b/packages/privatize/__tests__/index.js
@@ -4,7 +4,7 @@ var Privatize = require('..');
 describe('@stamp/privatize', function () {
   it('applies access restrictions', function () {
     var accessFoo, accessBar;
-    var orig = compose({
+    var Orig = compose({
       properties: {foo: 1},
       methods: {
         bar: function () {},
@@ -14,14 +14,14 @@ describe('@stamp/privatize', function () {
         }
       }
     });
-    var Stamp = orig.compose(Privatize).privatizeMethods('bar');
+    var Stamp = Orig.compose(Privatize).privatizeMethods('bar');
     var instance = Stamp();
 
     expect(instance.foo).toBeUndefined();
     expect(instance.bar).toBeUndefined();
     instance.checkAccess();
     expect(accessFoo).toBe(1);
-    expect(accessBar).toBe(orig.compose.methods.bar);
+    expect(accessBar).toBe(Orig.compose.methods.bar);
   });
 
   it('should push the initializer to the end of the list', function () {
@@ -48,10 +48,33 @@ describe('@stamp/privatize', function () {
 
   it('should work without any methods defined', function () {
     var Stamp = compose(Privatize, {
-      properties: { bar: 'foo' },
+      properties: { bar: 'foo' }
     });
     var instance = Stamp();
 
     expect(instance.bar).toBeUndefined();
+  });
+
+  it('can be used as a standalone function', function () {
+    var privatizeMethods = Privatize.privatizeMethods;
+    var accessFoo, accessBar;
+    var Orig = compose({
+      properties: {foo: 1},
+      methods: {
+        bar: function () {},
+        checkAccess: function () {
+          accessFoo = this.foo;
+          accessBar = this.bar;
+        }
+      }
+    });
+    var Stamp = privatizeMethods('bar').compose(Orig);
+    var instance = Stamp();
+
+    expect(instance.foo).toBeUndefined();
+    expect(instance.bar).toBeUndefined();
+    instance.checkAccess();
+    expect(accessFoo).toBe(1);
+    expect(accessBar).toBe(Orig.compose.methods.bar);
   })
 });

--- a/packages/privatize/index.js
+++ b/packages/privatize/index.js
@@ -38,11 +38,12 @@ function initializer(_, opts) {
   return newObject;
 }
 
-module.exports = compose({
+var Privatize = compose({
   initializers: [initializer],
   deepConfiguration: {Privatize: {methods: []}},
   staticProperties: {
     privatizeMethods: function () {
+      'use strict';
       var methodNames = [];
       for (var i = 0; i < arguments.length; i++) {
         var arg = arguments[i];
@@ -50,7 +51,8 @@ module.exports = compose({
           methodNames.push(arg);
         }
       }
-      return this.compose({
+      var Stamp = this && this.compose ? this : Privatize;
+      return Stamp.compose({
         deepConfiguration: {
           Privatize: {
             methods: methodNames
@@ -66,3 +68,5 @@ module.exports = compose({
     initializers.push(initializer);
   }]
 });
+
+module.exports = Privatize;

--- a/packages/privatize/package.json
+++ b/packages/privatize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/privatize",
-  "version": "0.1.7",
+  "version": "1.0.0",
   "description": "Protect private properties",
   "main": "index.js",
   "repository": {
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@stamp/compose": "^0.1.6"
+    "@stamp/compose": "^1.0.0"
   }
 }

--- a/packages/shortcut/__tests__/index.js
+++ b/packages/shortcut/__tests__/index.js
@@ -3,7 +3,7 @@ var Shortcut = require('..');
 
 expect.extend({
   toBeA: function (received, argument) {
-    const pass = typeof received === argument;
+    var pass = typeof received === argument;
     return {
       pass: pass,
       message: function () {

--- a/packages/shortcut/package.json
+++ b/packages/shortcut/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stamp/shortcut",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "description": "Adds handy shortcuts for stamp composition",
   "main": "index.js",
   "repository": {
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@stamp/compose": "^0.1.6"
+    "@stamp/compose": "^1.0.0"
   }
 }


### PR DESCRIPTION
Allow using static methods as standalone functions in 4 stamps: ArgOverProp, Collision, Named, Privatize

```js
import {argOverProp} from '@stamp/arg-over-prop';
import {collisionSetup} from '@stamp/collision';
import {setName} from '@stamp/named';
import {privatizeMethods} from '@stamp/privatize';
```