### PR TITLE
@stamp/it Add another non-spec metadata - "name" to change factory name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,26 +56,28 @@
       }
     },
     "@stamp/compose": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@stamp/compose/-/compose-0.1.5.tgz",
-      "integrity": "sha1-axgNg0A6qly7x8nhIQ2L6YqXFm0=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stamp/compose/-/compose-1.0.2.tgz",
+      "integrity": "sha512-TW1/jTGesxfkFRZUNTgQ9r4Ln6YaIArZmi836o21szc8z+gxrIWrYAtI4r9LfxeD9tnTymAjB1TtvJ19OYFo3Q==",
       "requires": {
-        "@stamp/core": "0.1.2",
-        "@stamp/is": "0.1.2"
+        "@stamp/core": "1.0.1",
+        "@stamp/is": "1.0.0"
+      },
+      "dependencies": {
+        "@stamp/core": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@stamp/core/-/core-1.0.1.tgz",
+          "integrity": "sha512-oZMdU17ZgUJOHHtHXXTb4afmGKpH2kNFfXYpkd3Scs3U+1ygyqFQrpzo/F2qrnEHJOXfvBafyvA/2u4Pdm+R9g==",
+          "requires": {
+            "@stamp/is": "1.0.0"
+          }
+        },
+        "@stamp/is": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@stamp/is/-/is-1.0.0.tgz",
+          "integrity": "sha1-7fAxo7Q+4fB+e3S/vYN8gpgOslo="
+        }
       }
-    },
-    "@stamp/core": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@stamp/core/-/core-0.1.2.tgz",
-      "integrity": "sha1-zX0eF0+pu5G/2TzYp/Lmm+qj8Us=",
-      "requires": {
-        "@stamp/is": "0.1.2"
-      }
-    },
-    "@stamp/is": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@stamp/is/-/is-0.1.2.tgz",
-      "integrity": "sha1-WpftjoKF8pMOwJhG9RB6goVtd+A="
     },
     "JSONStream": {
       "version": "1.3.1",

--- a/packages/collision/index.js
+++ b/packages/collision/index.js
@@ -16,7 +16,7 @@ function dedupe(array) {
 function makeProxyFunction(functions, name) {
   function deferredFn() {
     'use strict';
-    const results = [];
+    var results = [];
     for (var i = 0; i < functions.length; i++) {
       results.push(functions[i].apply(this, arguments)); // jshint ignore:line
     }

--- a/packages/it/__tests__/index.js
+++ b/packages/it/__tests__/index.js
@@ -41,7 +41,10 @@ describe('@stamp/it', function () {
       statics: {s: 1},
       deepStatics: {ds: 1},
       conf: {c: 1},
-      deepConf: {dc: 1}
+      deepConf: {dc: 1},
+      propertyDescriptors: {pd: {value: 1}},
+      staticPropertyDescriptors: {spd: {value: 1}},
+      name: "1"
     }).compose;
 
     expect(descr.properties.p).toBe(1);
@@ -52,5 +55,8 @@ describe('@stamp/it', function () {
     expect(descr.staticDeepProperties.ds).toBe(1);
     expect(descr.configuration.c).toBe(1);
     expect(descr.deepConfiguration.dc).toBe(1);
+    expect(descr.propertyDescriptors.pd.value).toBe(1);
+    expect(descr.staticPropertyDescriptors.spd.value).toBe(1);
+    expect(descr.staticPropertyDescriptors.name.value).toBe("1");
   });
 });

--- a/packages/it/index.js
+++ b/packages/it/index.js
@@ -1,6 +1,7 @@
 var compose = require('@stamp/compose');
 var Shortcut = require('@stamp/shortcut');
 var isStamp = require('@stamp/is/stamp');
+var isString = require('@stamp/is/string');
 var isObject = require('@stamp/is/object');
 var isFunction = require('@stamp/is/function');
 var merge = require('@stamp/core/merge');
@@ -28,7 +29,6 @@ function standardiseDescriptor(descr) {
   var statics = descr.statics;
   var staticDeepProperties = descr.staticDeepProperties;
   var deepStatics = descr.deepStatics;
-  var spd = descr.staticPropertyDescriptors;
   var configuration = descr.configuration;
   var conf = descr.conf;
   var deepConfiguration = descr.deepConfiguration;
@@ -45,6 +45,9 @@ function standardiseDescriptor(descr) {
 
   var sdp = isObject(deepStatics) ? merge({}, deepStatics) : undefined;
   sdp = isObject(staticDeepProperties) ? merge(sdp, staticDeepProperties) : sdp;
+
+  var spd = descr.staticPropertyDescriptors;
+  if (isString(descr.name)) spd = assign({}, spd || {}, { name: { value: descr.name } });
 
   var c = isObject(conf) || isObject(configuration) ?
     assign({}, conf, configuration) : undefined;


### PR DESCRIPTION
Proposal details: https://github.com/stampit-org/stamp-specification/issues/121

TL;DR:
```js
const HaveName = stampit({
  name: "Superman"
});

HaveName.name === "Superman"  // instead of the default "Stamp"
```

Sibling PR: https://github.com/stampit-org/stampit/pull/338